### PR TITLE
Owin method modifier new action

### DIFF
--- a/recommendation/microsoft.owin.json
+++ b/recommendation/microsoft.owin.json
@@ -136,7 +136,7 @@
               "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
             }
           ],
-          "Description": "Add a comment to explain how to remove the base class of OwinMiddleware.",
+          "Description": "Remove the base class of OwinMiddleware and replace the method modifiers for the invoke method to only public so as to remove the override modifier.",
           "Actions": [
             {
               "Name": "RemoveBaseClass",
@@ -155,7 +155,7 @@
                 "methodName": "Invoke",
                 "modifiers": "public"
               },
-              "Description": "Remove the override modifier from the invoke method in owin middleware.",
+              "Description": "Replace all the invoke method modifiers with only public in order to remove the override modifier.",
               "ActionValidation": {
                 "Contains": "public",
                 "NotContains": "override"

--- a/recommendation/microsoft.owin.json
+++ b/recommendation/microsoft.owin.json
@@ -139,13 +139,13 @@
           "Description": "Add a comment to explain how to remove the base class of OwinMiddleware.",
           "Actions": [
             {
-              "Name": "AddComment",
+              "Name": "RemoveBaseClass",
               "Type": "Class",
-              "Value": "Please remove the base class here : OwinMiddleware",
-              "Description": "Add a comment to remove the base class OwinMiddleware",
+              "Value": "OwinMiddleware",
+              "Description": "Remove the base class OwinMiddleware",
               "ActionValidation": {
-                "Contains": "Pleaseremovethebaseclasshere:OwinMiddleware",
-                "NotContains": ""
+                "Contains": "",
+                "NotContains": ":OwinMiddleware"
               }
             },
             {

--- a/recommendation/microsoft.owin.json
+++ b/recommendation/microsoft.owin.json
@@ -147,6 +147,19 @@
                 "Contains": "Pleaseremovethebaseclasshere:OwinMiddleware",
                 "NotContains": ""
               }
+            },
+            {
+              "Name": "ReplaceMethodModifiers",
+              "Type": "Class",
+              "Value": {
+                "methodName": "Invoke",
+                "modifiers": "public"
+              },
+              "Description": "Remove the override modifier from the invoke method in owin middleware.",
+              "ActionValidation": {
+                "Contains": "public",
+                "NotContains": "override"
+              }
             }
           ]
         }


### PR DESCRIPTION
*Issue #, if available:*
We need a new rule to remove the override modifier from Invoke method declaration inside of classes implementing the OwinMiddleware base class.

*Description of changes:*

Added a new owin rule to remove the override modifier form owinMiddleware base class type of classes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
