### PR TITLE
add antlr porting rules

### DIFF
--- a/recommendation/antlr.runtime.json
+++ b/recommendation/antlr.runtime.json
@@ -1,0 +1,54 @@
+{
+  "Name": "Antlr.Runtime",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Value": "Antlr",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Antlr.Runtime",
+      "Value": "Antlr.Runtime",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to Antlr3.Runtime",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Antlr3.Runtime",
+              "Description": "Add package Antlr3.Runtime"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/recommendation/antlr.runtime.misc.json
+++ b/recommendation/antlr.runtime.misc.json
@@ -1,0 +1,54 @@
+{
+  "Name": "Antlr.Runtime.Misc",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Value": "Antlr",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Antlr.Runtime.Misc",
+      "Value": "Antlr.Runtime.Misc",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add reference to Antlr3.Runtime",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Antlr3.Runtime",
+              "Description": "Add package Antlr3.Runtime"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/recommendation/antlr.runtime.tree.json
+++ b/recommendation/antlr.runtime.tree.json
@@ -1,0 +1,54 @@
+{
+  "Name": "Antlr.Runtime.Tree",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Value": "Antlr",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Antlr.Runtime.Tree",
+      "Value": "Antlr.Runtime.Tree",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to Antlr3.Runtime",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Antlr3.Runtime",
+              "Description": "Add package Antlr3.Runtime"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/porting-assistant-dotnet-datastore/issues/28

*Description of changes:*
* Add porting rules to add `Antlr3.Runtime`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
