### PR TITLE
add porting rules for ionic.zip

### DIFF
--- a/recommendation/ionic.bzip2.json
+++ b/recommendation/ionic.bzip2.json
@@ -1,0 +1,54 @@
+{
+  "Name": "Ionic.BZip2",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Value": "Ionic.Zip",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Ionic.BZip2",
+      "Value": "Ionic.BZip2",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to DotNetZip",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "DotNetZip",
+              "Description": "Add package DotNetZip"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/recommendation/ionic.bzip2.json
+++ b/recommendation/ionic.bzip2.json
@@ -38,7 +38,7 @@
               ]
             }
           ],
-          "Description": "Add a reference to DotNetZip",
+          "Description": "Add a reference to DotNetZip.",
           "Actions": [
             {
               "Name": "AddPackage",

--- a/recommendation/ionic.crc.json
+++ b/recommendation/ionic.crc.json
@@ -38,7 +38,7 @@
               ]
             }
           ],
-          "Description": "Add a reference to DotNetZip",
+          "Description": "Add a reference to DotNetZip.",
           "Actions": [
             {
               "Name": "AddPackage",

--- a/recommendation/ionic.crc.json
+++ b/recommendation/ionic.crc.json
@@ -1,0 +1,54 @@
+{
+  "Name": "Ionic.Crc",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Value": "Ionic.Zip",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Ionic.Crc",
+      "Value": "Ionic.Crc",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to DotNetZip",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "DotNetZip",
+              "Description": "Add package DotNetZip"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/recommendation/ionic.json
+++ b/recommendation/ionic.json
@@ -1,0 +1,54 @@
+{
+  "Name": "Ionic",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Value": "Ionic.Zip",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Ionic",
+      "Value": "Ionic",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to DotNetZip",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "DotNetZip",
+              "Description": "Add package DotNetZip"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/recommendation/ionic.json
+++ b/recommendation/ionic.json
@@ -38,7 +38,7 @@
               ]
             }
           ],
-          "Description": "Add a reference to DotNetZip",
+          "Description": "Add a reference to DotNetZip.",
           "Actions": [
             {
               "Name": "AddPackage",

--- a/recommendation/ionic.zip.json
+++ b/recommendation/ionic.zip.json
@@ -38,7 +38,7 @@
               ]
             }
           ],
-          "Description": "Add a reference to DotNetZip",
+          "Description": "Add a reference to DotNetZip.",
           "Actions": [
             {
               "Name": "AddPackage",

--- a/recommendation/ionic.zip.json
+++ b/recommendation/ionic.zip.json
@@ -1,0 +1,54 @@
+{
+  "Name": "Ionic.Zip",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Value": "Ionic.Zip",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Ionic.Zip",
+      "Value": "Ionic.Zip",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to DotNetZip",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "DotNetZip",
+              "Description": "Add package DotNetZip"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/recommendation/ionic.zlib.json
+++ b/recommendation/ionic.zlib.json
@@ -1,0 +1,54 @@
+{
+  "Name": "Ionic.Zlib",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Value": "Ionic.Zip",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "Ionic.Zlib",
+      "Value": "Ionic.Zlib",
+      "KeyType": "Name",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [
+                "x86",
+                "x64",
+                "ARM32",
+                "ARM64"
+              ]
+            }
+          ],
+          "Description": "Add a reference to DotNetZip",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "DotNetZip",
+              "Description": "Add package DotNetZip"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/recommendation/ionic.zlib.json
+++ b/recommendation/ionic.zlib.json
@@ -38,7 +38,7 @@
               ]
             }
           ],
-          "Description": "Add a reference to DotNetZip",
+          "Description": "Add a reference to DotNetZip.",
           "Actions": [
             {
               "Name": "AddPackage",


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/porting-assistant-dotnet-datastore/issues/30

*Description of changes:*
* adds porting rules for Ionic.Zip

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
