### PR TITLE
New owin rules for branching pipelines gap

### DIFF
--- a/recommendation/microsoft.owin.json
+++ b/recommendation/microsoft.owin.json
@@ -136,7 +136,7 @@
               "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
             }
           ],
-          "Description": "Add a comment to explain how to remove the base class of OwinMiddleware.",
+          "Description": "Remove the base class for owin middleware, remove the override method modifier for the invoke method, add a new gloable xpression for RequestDelegate _next, initialize it in the constructor and remove the constructor intializer base(next).",
           "Actions": [
             {
               "Name": "RemoveBaseClass",

--- a/recommendation/microsoft.owin.json
+++ b/recommendation/microsoft.owin.json
@@ -162,17 +162,17 @@
               }
             },
             {
-              "Name": "AddGlobalExpression",
+              "Name": "AddExpression",
               "Type": "Class",
-              "Value": "RequestDelegate _next = null;",
+              "Value": "RequestDelegate _next = null; //CTA Change",
               "Description": "Add a new global variable to replace the OwinMiddleware global abstract variable of Next.",
               "ActionValidation": {
-                "Contains": "RequestDelegate_next=null;",
+                "Contains": "RequestDelegate_next=null;//CTAChange",
                 "NotContains": ""
               }
             },
             {
-              "Name": "AddConstructorExpression",
+              "Name": "AppendConstructorExpression",
               "Type": "Class",
               "Value": "_next = next;",
               "Description": "Add a new expression in the constructor to initialize the new variable of _next to the next element in the pipeline.",

--- a/recommendation/microsoft.owin.json
+++ b/recommendation/microsoft.owin.json
@@ -139,13 +139,56 @@
           "Description": "Add a comment to explain how to remove the base class of OwinMiddleware.",
           "Actions": [
             {
-              "Name": "AddComment",
+              "Name": "RemoveBaseClass",
               "Type": "Class",
-              "Value": "Please remove the base class here : OwinMiddleware",
-              "Description": "Add a comment to remove the base class OwinMiddleware",
+              "Value": "OwinMiddleware",
+              "Description": "Remove the base class OwinMiddleware",
               "ActionValidation": {
-                "Contains": "Pleaseremovethebaseclasshere:OwinMiddleware",
+                "Contains": "",
+                "NotContains": ":OwinMiddleware"
+              }
+            },
+            {
+              "Name": "ReplaceMethodModifiers",
+              "Type": "Class",
+              "Value": {
+                "methodName": "Invoke",
+                "modifiers": "public"
+              },
+              "Description": "Replace all the invoke method modifiers with only public in order to remove the override modifier.",
+              "ActionValidation": {
+                "Contains": "public",
+                "NotContains": "override"
+              }
+            },
+            {
+              "Name": "AddGlobalExpression",
+              "Type": "Class",
+              "Value": "RequestDelegate _next = null;",
+              "Description": "Add a new global variable to replace the OwinMiddleware global abstract variable of Next.",
+              "ActionValidation": {
+                "Contains": "RequestDelegate_next=null;",
                 "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddConstructorExpression",
+              "Type": "Class",
+              "Value": "_next = next;",
+              "Description": "Add a new expression in the constructor to initialize the new variable of _next to the next element in the pipeline.",
+              "ActionValidation": {
+                "Contains": "_next=next;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveConstructorInitializer",
+              "Type": "Class",
+              "Value": "next",
+              "Description": "Remove the base initializer for the constructor.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": ":base(next)"
               }
             }
           ]
@@ -279,7 +322,7 @@
     {
       "Type": "Method",
       "Name": "Invoke",
-      "Value": "Microsoft.Owin.OwinMiddleware.Invoke(Microsoft.Owin.IOwinContext)",
+      "Value": "Microsoft.Owin.OwinMiddleware.Invoke",
       "KeyType": "Name",
       "ContainingType": "OwinMiddleware",
       "RecommendedActions": [
@@ -296,15 +339,15 @@
               "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
             }
           ],
-          "Description": "Add a comment to explain how to replace the Next variable with a globallly declared _next.",
+          "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
           "Actions": [
             {
-              "Name": "AddComment",
+              "Name": "ReplaceMethod",
               "Type": "Method",
-              "Value": "Please replace Next with a globally declared RequestDelegate _next which is initialized in the constructor with the next element of the pipeline.",
-              "Description": "Add a comment to explain how to replace the Next variable with a globallly declared _next.",
+              "Value": "_next.Invoke",
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
               "ActionValidation": {
-                "Contains": "PleasereplaceNextwithagloballydeclaredRequestDelegate_next",
+                "Contains": "_next.Invoke",
                 "NotContains": ""
               }
             }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/porting-assistant-dotnet-datastore/issues/33

*Description of changes:*
Added an Owin rule to add a global variable within an owin middleware object to hold the next pipeline element.
Added an Owin rule to remove the constructor initializer within an owin middleware object.
Added an Owin rule to add an expression to initialize the next pipeline object within an owin middleware constructor.
Added an Owin rule to remove reference to the OwinMiddleware Next variable and replace it with a newly declared pipeline object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
