### PR TITLE
Invocation expression more precise keys rules

### DIFF
--- a/recommendation/microsoft.owin.hosting.json
+++ b/recommendation/microsoft.owin.hosting.json
@@ -3,7 +3,7 @@
   "Version": "1.0.0",
   "Packages": [
     {
-      "Name": "Owin",
+      "Name": "Microsoft.Owin.Hosting",
       "Type": "Nuget"
     }
   ],
@@ -88,8 +88,44 @@
     },
     {
       "Type": "Method",
-      "Name": "Start",
-      "Value": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>",
+      "Name": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>(Microsoft.Owin.Hosting.StartOptions)",
+      "Value": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>(Microsoft.Owin.Hosting.StartOptions)",
+      "KeyType": "Name",
+      "ContainingType": "WebApp",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace WebApp.Start.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Replace Microsoft.Owin.Hosting.WebApp.Start with WebHostBuilder such as: var host = new WebHostBuilder().UseKestrel().UseUrls(URL_HERE).UseStartup<Startup>().Build(); host.Start();",
+              "Description": "Add a comment to explain how to replace WebApp.Start.",
+              "ActionValidation": {
+                "Contains": "ReplaceMicrosoft.Owin.Hosting.WebApp.StartwithWebHostBuilder",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>(string)",
+      "Value": "Microsoft.Owin.Hosting.WebApp.Start<TStartup>(string)",
       "KeyType": "Name",
       "ContainingType": "WebApp",
       "RecommendedActions": [

--- a/recommendation/microsoft.owin.json
+++ b/recommendation/microsoft.owin.json
@@ -3,7 +3,7 @@
   "Version": "1.0.0",
   "Packages": [
     {
-      "Name": "Owin",
+      "Name": "Microsoft.Owin",
       "Type": "Nuget"
     }
   ],
@@ -136,7 +136,7 @@
               "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
             }
           ],
-          "Description": "Remove the base class of OwinMiddleware and replace the method modifiers for the invoke method to only public so as to remove the override modifier.",
+          "Description": "Remove the base class for owin middleware, remove the override method modifier for the invoke method, add a new gloable xpression for RequestDelegate _next, initialize it in the constructor and remove the constructor intializer base(next).",
           "Actions": [
             {
               "Name": "RemoveBaseClass",
@@ -159,6 +159,36 @@
               "ActionValidation": {
                 "Contains": "public",
                 "NotContains": "override"
+              }
+            },
+            {
+              "Name": "AddExpression",
+              "Type": "Class",
+              "Value": "RequestDelegate _next = null; //CTA Change",
+              "Description": "Add a new global variable to replace the OwinMiddleware global abstract variable of Next.",
+              "ActionValidation": {
+                "Contains": "RequestDelegate_next=null;//CTAChange",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AppendConstructorExpression",
+              "Type": "Class",
+              "Value": "_next = next;",
+              "Description": "Add a new expression in the constructor to initialize the new variable of _next to the next element in the pipeline.",
+              "ActionValidation": {
+                "Contains": "_next=next;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveConstructorInitializer",
+              "Type": "Class",
+              "Value": "next",
+              "Description": "Remove the base initializer for the constructor.",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": ":base(next)"
               }
             }
           ]
@@ -212,86 +242,8 @@
       ]
     },
     {
-      "Type": "Namespace",
-      "Name": "StaticFiles",
-      "Value": "Microsoft.Owin.StaticFiles",
-      "KeyType": "Method",
-      "ContainingType": "",
-      "RecommendedActions": [
-        {
-          "Source": "Amazon",
-          "Preferred": "Yes",
-          "TargetFrameworks": [
-            {
-              "Name": "netcoreapp3.1",
-              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
-            },
-            {
-              "Name": "net5.0",
-              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
-            }
-          ],
-          "Description": "Add Microsoft.AspNetCore.StaticFiles and Microsoft.Extensions.FileProviders.Physical packages. Add Microsoft.Extensions.FileProviders and Microsoft.AspNetCore.StaticFiles namespaces. Remove Microsoft.Owin.StaticFiles and Microsoft.Owin.FileSystems namespaces.",
-          "Actions": [
-            {
-              "Name": "AddPackage",
-              "Type": "Package",
-              "Value": "Microsoft.AspNetCore.StaticFiles",
-              "Description": "Add package Microsoft.AspNetCore.StaticFiles"
-            },
-            {
-              "Name": "AddPackage",
-              "Type": "Package",
-              "Value": "Microsoft.Extensions.FileProviders.Physical",
-              "Description": "Add package Microsoft.Extensions.FileProviders.Physical"
-            },
-            {
-              "Name": "AddDirective",
-              "Type": "Using",
-              "Value": "Microsoft.Extensions.FileProviders",
-              "Description": "Add Microsoft.Extensions.FileProviders",
-              "ActionValidation": {
-                "Contains": "usingMicrosoft.Extensions.FileProviders;",
-                "NotContains": ""
-              }
-            },
-            {
-              "Name": "AddDirective",
-              "Type": "Using",
-              "Value": "Microsoft.AspNetCore.StaticFiles",
-              "Description": "Add Microsoft.AspNetCore.StaticFiles",
-              "ActionValidation": {
-                "Contains": "usingMicrosoft.AspNetCore.StaticFiles;",
-                "NotContains": ""
-              }
-            },
-            {
-              "Name": "RemoveDirective",
-              "Type": "Using",
-              "Value": "Microsoft.Owin.StaticFiles",
-              "Description": "Remove Microsoft.Owin.StaticFiles namespace",
-              "ActionValidation": {
-                "Contains": "",
-                "NotContains": "usingMicrosoft.Owin.StaticFiles;"
-              }
-            },
-            {
-              "Name": "RemoveDirective",
-              "Type": "Using",
-              "Value": "Microsoft.Owin.FileSystems",
-              "Description": "Remove Microsoft.Owin.FileSystems namespace",
-              "ActionValidation": {
-                "Contains": "",
-                "NotContains": "usingMicrosoft.Owin.FileSystems;"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
       "Type": "Method",
-      "Name": "Invoke",
+      "Name": "Microsoft.Owin.OwinMiddleware.Invoke(Microsoft.Owin.IOwinContext)",
       "Value": "Microsoft.Owin.OwinMiddleware.Invoke(Microsoft.Owin.IOwinContext)",
       "KeyType": "Name",
       "ContainingType": "OwinMiddleware",
@@ -309,15 +261,15 @@
               "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
             }
           ],
-          "Description": "Add a comment to explain how to replace the Next variable with a globallly declared _next.",
+          "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
           "Actions": [
             {
-              "Name": "AddComment",
+              "Name": "ReplaceMethod",
               "Type": "Method",
-              "Value": "Please replace Next with a globally declared RequestDelegate _next which is initialized in the constructor with the next element of the pipeline.",
-              "Description": "Add a comment to explain how to replace the Next variable with a globallly declared _next.",
+              "Value": "_next.Invoke",
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
               "ActionValidation": {
-                "Contains": "PleasereplaceNextwithagloballydeclaredRequestDelegate_next",
+                "Contains": "_next.Invoke",
                 "NotContains": ""
               }
             }
@@ -327,7 +279,7 @@
     },
     {
       "Type": "Method",
-      "Name": "Get",
+      "Name": "Microsoft.Owin.IReadableStringCollection.Get(string)",
       "Value": "Microsoft.Owin.IReadableStringCollection.Get(string)",
       "KeyType": "Name",
       "ContainingType": "IReadableStringCollection",

--- a/recommendation/microsoft.owin.json
+++ b/recommendation/microsoft.owin.json
@@ -136,7 +136,7 @@
               "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
             }
           ],
-          "Description": "Remove the base class for owin middleware, remove the override method modifier for the invoke method, add a new gloable xpression for RequestDelegate _next, initialize it in the constructor and remove the constructor intializer base(next).",
+          "Description": "Remove the base class for owin middleware, remove the override method modifier for the invoke method, add a new global expression for RequestDelegate _next, initialize it in the constructor and remove the constructor intializer base(next).",
           "Actions": [
             {
               "Name": "RemoveBaseClass",
@@ -164,10 +164,10 @@
             {
               "Name": "AddExpression",
               "Type": "Class",
-              "Value": "RequestDelegate _next = null; //CTA Change",
+              "Value": "RequestDelegate _next = null; //PortingAssistant Change",
               "Description": "Add a new global variable to replace the OwinMiddleware global abstract variable of Next.",
               "ActionValidation": {
-                "Contains": "RequestDelegate_next=null;//CTAChange",
+                "Contains": "RequestDelegate_next=null;//PortingAssistantChange",
                 "NotContains": ""
               }
             },

--- a/recommendation/microsoft.owin.staticfiles.json
+++ b/recommendation/microsoft.owin.staticfiles.json
@@ -1,0 +1,216 @@
+{
+  "Name": "Microsoft.Owin.StaticFiles",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.StaticFiles",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Namespace",
+      "Name": "StaticFiles",
+      "Value": "Microsoft.Owin.StaticFiles",
+      "KeyType": "Method",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.StaticFiles and Microsoft.Extensions.FileProviders.Physical packages. Add Microsoft.Extensions.FileProviders and Microsoft.AspNetCore.StaticFiles namespaces. Remove Microsoft.Owin.StaticFiles and Microsoft.Owin.FileSystems namespaces.",
+          "Actions": [
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.StaticFiles",
+              "Description": "Add package Microsoft.AspNetCore.StaticFiles"
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.Extensions.FileProviders.Physical",
+              "Description": "Add package Microsoft.Extensions.FileProviders.Physical"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Extensions.FileProviders",
+              "Description": "Add Microsoft.Extensions.FileProviders",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.Extensions.FileProviders;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.StaticFiles",
+              "Description": "Add Microsoft.AspNetCore.StaticFiles",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.StaticFiles;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.StaticFiles",
+              "Description": "Remove Microsoft.Owin.StaticFiles namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingMicrosoft.Owin.StaticFiles;"
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.FileSystems",
+              "Description": "Remove Microsoft.Owin.FileSystems namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingMicrosoft.Owin.FileSystems;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "ObjectCreation",
+      "Name": "Microsoft.Owin.StaticFiles.FileServerOptions.FileServerOptions()",
+      "Value": "Microsoft.Owin.StaticFiles.FileServerOptions.FileServerOptions()",
+      "KeyType": "Name",
+      "ContainingType": "FileServerOptions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace FileServerOptions' FileSystem with FileProvider and PhysicalFileSystem with PhysicalFileProvider.",
+          "Actions": [
+            {
+              "Name": "ReplaceOrAddObjectPropertyIdentifier",
+              "Type": "ObjectCreation",
+              "Value": {
+                "oldMember": "FileSystem",
+                "newMember": "FileProvider",
+                "newValueIfAdding": "new PhysicalFileProvider(@\"\")"
+              },
+              "Description": "Replace FileServerOptions' FileSystem with FileProvider",
+              "ActionValidation": {
+                "Contains": "FileProvider",
+                "NotContains": "FileSystem"
+              }
+            },
+            {
+              "Name": "ReplaceObjectPropertyValue",
+              "Type": "ObjectCreation",
+              "Value": {
+                "oldMember": "PhysicalFileSystem",
+                "newMember": "PhysicalFileProvider"
+              },
+              "Description": "Replace PhysicalFileSystem with PhysicalFileProvider",
+              "ActionValidation": {
+                "Contains": "PhysicalFileProvider",
+                "NotContains": "PhysicalFileSystem"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "ObjectCreation",
+              "Value": "If FileSystem was not present before FileProvider was added, please initialize this new value. Using the value from RequestPath with System.IO.Directory.GetCurrentDirectory() as a prefix may be  agood starting point.",
+              "Description": "Add a comment to explain how to initialize FileProvider correctly.",
+              "ActionValidation": {
+                "Contains": "IfFileSystemwasnotpresentbeforeFileProviderwasadded,pleaseinitializethisnewvalue.",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "ObjectCreation",
+      "Name": "Microsoft.Owin.StaticFiles.DirectoryBrowserOptions.DirectoryBrowserOptions()",
+      "Value": "Microsoft.Owin.StaticFiles.DirectoryBrowserOptions.DirectoryBrowserOptions()",
+      "KeyType": "Name",
+      "ContainingType": "DirectoryBrowserOptions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace DirectoryBrowserOptions' FileSystem with FileProvider and PhysicalFileSystem with PhysicalFileProvider.",
+          "Actions": [
+            {
+              "Name": "ReplaceOrAddObjectPropertyIdentifier",
+              "Type": "ObjectCreation",
+              "Value": {
+                "oldMember": "FileSystem",
+                "newMember": "FileProvider",
+                "newValueIfAdding": "new PhysicalFileProvider(@\"\")"
+              },
+              "Description": "Replace DirectoryBrowserOptions' FileSystem with FileProvider",
+              "ActionValidation": {
+                "Contains": "FileProvider",
+                "NotContains": "FileSystem"
+              }
+            },
+            {
+              "Name": "ReplaceObjectPropertyValue",
+              "Type": "ObjectCreation",
+              "Value": {
+                "oldMember": "PhysicalFileSystem",
+                "newMember": "PhysicalFileProvider"
+              },
+              "Description": "Replace PhysicalFileSystem with PhysicalFileProvider",
+              "ActionValidation": {
+                "Contains": "PhysicalFileProvider",
+                "NotContains": "PhysicalFileSystem"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "ObjectCreation",
+              "Value": "If FileSystem was not present before FileProvider was added, please initialize this new value. Using the value from RequestPath with System.IO.Directory.GetCurrentDirectory() as a prefix may be  agood starting point.",
+              "Description": "Add a comment to explain how to initialize FileProvider correctly.",
+              "ActionValidation": {
+                "Contains": "IfFileSystemwasnotpresentbeforeFileProviderwasadded,pleaseinitializethisnewvalue.",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/recommendation/owin.json
+++ b/recommendation/owin.json
@@ -72,7 +72,7 @@
     },
     {
       "Type": "Method",
-      "Name": "Use",
+      "Name": "Owin.IAppBuilder.Use(object, params object[])",
       "Value": "Owin.IAppBuilder.Use(object, params object[])",
       "KeyType": "Name",
       "ContainingType": "IAppBuilder",
@@ -108,7 +108,7 @@
     },
     {
       "Type": "Method",
-      "Name": "Use",
+      "Name": "Owin.IAppBuilder.Use<T>(params object[])",
       "Value": "Owin.IAppBuilder.Use<T>(params object[])",
       "KeyType": "Name",
       "ContainingType": "AppBuilderUseExtensions",
@@ -144,7 +144,7 @@
     },
     {
       "Type": "Method",
-      "Name": "Use",
+      "Name": "Owin.IAppBuilder.Use(System.Func<Microsoft.Owin.IOwinContext, System.Func<System.Threading.Tasks.Task>, System.Threading.Tasks.Task>)",
       "Value": "Owin.IAppBuilder.Use(System.Func<Microsoft.Owin.IOwinContext, System.Func<System.Threading.Tasks.Task>, System.Threading.Tasks.Task>)",
       "KeyType": "Name",
       "ContainingType": "AppBuilderUseExtensions",
@@ -180,7 +180,7 @@
     },
     {
       "Type": "Method",
-      "Name": "UseWebApi",
+      "Name": "Owin.IAppBuilder.UseWebApi(System.Web.Http.HttpConfiguration)",
       "Value": "Owin.IAppBuilder.UseWebApi(System.Web.Http.HttpConfiguration)",
       "KeyType": "Name",
       "ContainingType": "WebApiAppBuilderExtensions",
@@ -266,7 +266,7 @@
     },
     {
       "Type": "Method",
-      "Name": "MapSignalR",
+      "Name": "Owin.IAppBuilder.MapSignalR()",
       "Value": "Owin.IAppBuilder.MapSignalR()",
       "KeyType": "Name",
       "ContainingType": "OwinExtensions",
@@ -348,7 +348,7 @@
     },
     {
       "Type": "Method",
-      "Name": "UseErrorPage",
+      "Name": "Owin.IAppBuilder.UseErrorPage()",
       "Value": "Owin.IAppBuilder.UseErrorPage()",
       "KeyType": "Name",
       "ContainingType": "ErrorPageExtensions",
@@ -384,43 +384,7 @@
     },
     {
       "Type": "Method",
-      "Name": "UseFileServer",
-      "Value": "Owin.IAppBuilder.UseFileServer(Microsoft.Owin.StaticFiles.FileServerOptions)",
-      "KeyType": "Name",
-      "ContainingType": "FileServerExtensions",
-      "RecommendedActions": [
-        {
-          "Source": "Amazon",
-          "Preferred": "Yes",
-          "TargetFrameworks": [
-            {
-              "Name": "netcoreapp3.1",
-              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
-            },
-            {
-              "Name": "net5.0",
-              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
-            }
-          ],
-          "Description": "Add a comment to explain how to use FileServerOptions and to ensure the usage of FileProvider attribute.",
-          "Actions": [
-            {
-              "Name": "AddComment",
-              "Type": "Method",
-              "Value": "Please replace the FileSystem property inside of the new FileServerOptions with FileProvider instead, if FileSystem is not initialized please add FileProvider.",
-              "Description": "Add a comment on how to setup your MVC controller in startup class.",
-              "ActionValidation": {
-                "Contains": "PleasereplacetheFileSystempropertyinsideofthenewFileServerOptionswithFileProvider",
-                "NotContains": ""
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Type": "Method",
-      "Name": "UseDirectoryBrowser",
+      "Name": "Owin.IAppBuilder.UseDirectoryBrowser(Microsoft.Owin.StaticFiles.DirectoryBrowserOptions)",
       "Value": "Owin.IAppBuilder.UseDirectoryBrowser(Microsoft.Owin.StaticFiles.DirectoryBrowserOptions)",
       "KeyType": "Name",
       "ContainingType": "DirectoryBrowserExtensions",
@@ -440,16 +404,6 @@
           ],
           "Description": "Add Microsoft.Extensions.DependencyInjection namespace. Add a comment to add ConfigureServices method and explain how to use FileProvider attribute inside of DirectoryBrowsingOptions class.",
           "Actions": [
-            {
-              "Name": "AddComment",
-              "Type": "Method",
-              "Value": "Please replace the FileSystem property inside of the new DirectoryBrowsingOptions with FileProvider instead, if FileSystem is not initialized please add FileProvider.",
-              "Description": "Add a comment on how to setup your MVC controller in startup class.",
-              "ActionValidation": {
-                "Contains": "PleasereplacetheFileSystempropertyinsideofthenewDirectoryBrowsingOptionswithFileProvider",
-                "NotContains": ""
-              }
-            },
             {
               "Name": "AddDirective",
               "Type": "Using",

--- a/recommendation/system.web.json
+++ b/recommendation/system.web.json
@@ -11,7 +11,7 @@
   "Recommendations": [
     {
       "Type": "Method",
-      "Name": "AppendHeader",
+      "Name": "System.Web.HttpResponse.AppendHeader(string, string)",
       "Value": "System.Web.HttpResponse.AppendHeader(string, string)",
       "KeyType": "Name",
       "ContainingType": "HttpResponse",
@@ -51,7 +51,7 @@
     },
     {
       "Type": "Method",
-      "Name": "HtmlEncode",
+      "Name": "System.Web.HttpServerUtilityBase.HtmlEncode(string)",
       "Value": "System.Web.HttpServerUtilityBase.HtmlEncode(string)",
       "KeyType": "Name",
       "ContainingType": "HttpServerUtilityBase",


### PR DESCRIPTION
*Issue #, if available:*
Currently Microsoft.Owin.Hosting.WebApp.Start and System.Diagnostics.Process.Start both match against an invocation expression rule for only the former.

The invocation expression keys are not precise enough.

*Description of changes:*
Make the keys for invocation expressions more specific.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
