### PR TITLE
modify owin rules to replace only method when needed.

### DIFF
--- a/recommendation/microsoft.owin.json
+++ b/recommendation/microsoft.owin.json
@@ -264,7 +264,7 @@
           "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
           "Actions": [
             {
-              "Name": "ReplaceMethod",
+              "Name": "ReplaceMethodWithObject",
               "Type": "Method",
               "Value": "_next.Invoke",
               "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",

--- a/recommendation/owin.json
+++ b/recommendation/owin.json
@@ -201,9 +201,12 @@
           "Description": "Replace UseWebApi with UseEndpoints and add a comment to create a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces and remove System.Web.Http namespace.",
           "Actions": [
             {
-              "Name": "ReplaceMethod",
+              "Name": "ReplaceOnlyMethod",
               "Type": "Method",
-              "Value": "Microsoft.AspNetCore.Builder.IApplicationBuilder.UseEndpoints",
+              "Value": {
+                "oldMethod": "UseWebApi",
+                "newMethod": "UseEndpoints"
+              },
               "Description": "Replace UseWebApi with UseEndpoints",
               "ActionValidation": {
                 "Contains": "UseEndpoints",
@@ -313,9 +316,12 @@
               }
             },
             {
-              "Name": "ReplaceMethod",
+              "Name": "ReplaceOnlyMethod",
               "Type": "Method",
-              "Value": "Microsoft.AspNetCore.Builder.IApplicationBuilder.UseSignalR",
+              "Value": {
+                "oldMethod": "MapSignalR",
+                "newMethod": "UseSignalR"
+              },
               "Description": "Replace MapSignalR with UseSignalR",
               "ActionValidation": {
                 "Contains": "UseSignalR",
@@ -369,9 +375,12 @@
           "Description": "Replace UseErrorPage with UseDeveloperExceptionPage.",
           "Actions": [
             {
-              "Name": "ReplaceMethod",
+              "Name": "ReplaceOnlyMethod",
               "Type": "Method",
-              "Value": "Microsoft.AspNetCore.Builder.IApplicationBuilder.UseDeveloperExceptionPage",
+              "Value": {
+                "oldMethod": "UseErrorPage",
+                "newMethod": "UseDeveloperExceptionPage"
+              },
               "Description": "Replace UseErrorPage with UseDeveloperExceptionPage",
               "ActionValidation": {
                 "Contains": "UseDeveloperExceptionPage",

--- a/recommendation/owin.json
+++ b/recommendation/owin.json
@@ -201,7 +201,7 @@
           "Description": "Replace UseWebApi with UseEndpoints and add a comment to create a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces and remove System.Web.Http namespace.",
           "Actions": [
             {
-              "Name": "ReplaceOnlyMethod",
+              "Name": "ReplaceMethodOnly",
               "Type": "Method",
               "Value": {
                 "oldMethod": "UseWebApi",
@@ -316,7 +316,7 @@
               }
             },
             {
-              "Name": "ReplaceOnlyMethod",
+              "Name": "ReplaceMethodOnly",
               "Type": "Method",
               "Value": {
                 "oldMethod": "MapSignalR",
@@ -375,7 +375,7 @@
           "Description": "Replace UseErrorPage with UseDeveloperExceptionPage.",
           "Actions": [
             {
-              "Name": "ReplaceOnlyMethod",
+              "Name": "ReplaceMethodOnly",
               "Type": "Method",
               "Value": {
                 "oldMethod": "UseErrorPage",

--- a/recommendation/system.web.json
+++ b/recommendation/system.web.json
@@ -32,7 +32,7 @@
           "Description": "Replace method AppendHeader with this.Response.Headers.Add. In the replacement, \"this\" refers to the controller object.",
           "Actions": [
             {
-              "Name": "ReplaceMethod",
+              "Name": "ReplaceMethodWithObject",
               "Type": "Method",
               "Value": "this.Response.Headers.Add",
               "Description": "Replace AppendHeader with a new method to add to headers.",
@@ -72,7 +72,7 @@
           "Description": "Replace HtmlEncode with a new method HtmlEncoder.Default.Encode in namepsace System.Text.Encodings.Web.",
           "Actions": [
             {
-              "Name": "ReplaceMethod",
+              "Name": "ReplaceMethodWithObject",
               "Type": "Method",
               "Value": "HtmlEncoder.Default.Encode",
               "Description": "Replace HtmlEncode with a new method: HtmlEncoder.Default.Encode.",


### PR DESCRIPTION
*Issue #44 

*Description of changes:*
Replace actions where we only wanted to match against a specific method and replace only the method name rather than the whole expression.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
