### PR TITLE
Add new owin namespace rules file

### DIFF
--- a/recommendation/microsoft.owin.filesystems.json
+++ b/recommendation/microsoft.owin.filesystems.json
@@ -1,0 +1,48 @@
+{
+  "Name": "Microsoft.Owin.FileSystems",
+  "Version": "1.0.0",
+  "Packages": [
+    {
+      "Name": "Microsoft.Owin.FileSystems",
+      "Type": "Nuget"
+    }
+  ],
+  "Recommendations": [
+    {
+      "Type": "Class",
+      "Name": "PhysicalFileSystem",
+      "Value": "Microsoft.Owin.FileSystems.PhysicalFileSystem",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace PhysicalFileSystem with PhysicalFileProvider.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "PhysicalFileProvider",
+              "Description": "Replace PhysicalFileSystem with PhysicalFileProvider",
+              "ActionValidation": {
+                "Contains": "PhysicalFileProvider",
+                "NotContains": "PhysicalFileSystem"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a new owin namespace rules file to cover all eventualities for PhysicalFileSystems rule so it also applies outside object creation nodes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
