### PR TITLE
Remove System.Web.Http namespace when updating web api namespaces

### DIFF
--- a/recommendation/system.web.http.json
+++ b/recommendation/system.web.http.json
@@ -142,9 +142,9 @@
             {
               "Name": "RemoveDirective",
               "Type": "Using",
-              "Value": "System.Web",
-              "Description": "Remove System.Web namespace.",
-              "ActionValidation":{"Contains":"", "NotContains":"usingSystem.Web;"}
+              "Value": "System.Web.Http",
+              "Description": "Remove System.Web.Http namespace.",
+              "ActionValidation":{"Contains":"", "NotContains":"usingSystem.Web.Http;"}
             }
           ]
         }


### PR DESCRIPTION
Remove System.Web.Http namespace when updating web api namespaces