### PR TITLE
Owin changes

### DIFF
--- a/recommendation/microsoft.owin.json
+++ b/recommendation/microsoft.owin.json
@@ -29,7 +29,10 @@
             {
               "Name": "AddPackage",
               "Type": "Package",
-              "Value": {"Name":"Microsoft.AspNetCore.Owin", "Version":"3.1.14"},
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Owin",
+                "Version": "3.1.14"
+              },
               "Description": "Add package Microsoft.AspNetCore.Owin"
             },
             {
@@ -411,6 +414,52 @@
       ]
     },
     {
+      "Type": "Class",
+      "Name": "IReadableStringCollection",
+      "Value": "Microsoft.Owin.IReadableStringCollection",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace IReadableStringCollection with IQueryCollection and add Microsoft.AspNetCore.Http.RequestDelegate namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "IQueryCollection",
+              "Description": "Replace IReadableStringCollection with IQueryCollection.",
+              "ActionValidation": {
+                "Contains": "IQueryCollection",
+                "NotContains": "IReadableStringCollection"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "Type": "Method",
       "Name": "Microsoft.Owin.IReadableStringCollection.Get(string)",
       "Value": "Microsoft.Owin.IReadableStringCollection.Get(string)",
@@ -441,6 +490,217 @@
                 "Contains": "Please replace Get with TryGetValue.",
                 "NotContains": "",
                 "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Microsoft.Owin.IOwinContext.Get<T>(string)",
+      "Value": "Microsoft.Owin.IOwinContext.Get<T>(string)",
+      "KeyType": "Name",
+      "ContainingType": "IOwinContext",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace the Get method with Items collection.",
+          "Actions": [
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace Get with Items. Such as (Casting_Type)context.Items[\"String_To_Search_For\"];",
+              "Description": "Add a comment to explain how to replace IOwinContext.Get with HttpContext.Items instead.",
+              "ActionValidation": {
+                "Contains": "Please replace Get with Items. Such as (Casting_Type)context.Items[\"String_To_Search_For\"];",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "RequestCookieCollection",
+      "Value": "Microsoft.Owin.RequestCookieCollection",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace RequestCookieCollection with IRequestCookieCollection and add Microsoft.AspNetCore.Http.RequestDelegate namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "IRequestCookieCollection",
+              "Description": "Replace RequestCookieCollection with IRequestCookieCollection.",
+              "ActionValidation": {
+                "Contains": "IRequestCookieCollection",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "ResponseCookieCollection",
+      "Value": "Microsoft.Owin.ResponseCookieCollection",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace ResponseCookieCollection with IResponseCookies and add Microsoft.AspNetCore.Http.RequestDelegate namespace.",
+          "Actions": [
+            {
+              "Name": "ReplaceIdentifier",
+              "Type": "Identifier",
+              "Value": "IResponseCookies",
+              "Description": "Replace ResponseCookieCollection with IResponseCookies.",
+              "ActionValidation": {
+                "Contains": "IResponseCookies",
+                "NotContains": "ResponseCookieCollection"
+              }
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "IHeaderDictionary",
+      "Value": "Microsoft.Owin.IHeaderDictionary",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.Http namespace.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Class",
+      "Name": "PathString",
+      "Value": "Microsoft.Owin.PathString",
+      "KeyType": "Identifier",
+      "ContainingType": "",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add Microsoft.AspNetCore.Http namespace if PathString is being used.",
+          "Actions": [
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Http",
+              "Description": "Add Microsoft.AspNetCore.Http namespace",
+              "ActionValidation": {
+                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin",
+              "Description": "Remove Microsoft.Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "usingMicrosoft.Owin;"
               }
             }
           ]

--- a/recommendation/microsoft.owin.json
+++ b/recommendation/microsoft.owin.json
@@ -653,7 +653,7 @@
               "Value": "Microsoft.AspNetCore.Http",
               "Description": "Add Microsoft.AspNetCore.Http namespace",
               "ActionValidation": {
-                "Contains": "usingMicrosoft.AspNetCore.Http;",
+                "Contains": "using Microsoft.AspNetCore.Http;",
                 "NotContains": ""
               }
             }

--- a/recommendation/owin.json
+++ b/recommendation/owin.json
@@ -90,15 +90,29 @@
               "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
             }
           ],
-          "Description": "Add a comment to help replace Owin.IAppBuilder.Use with .UseOwin.",
+          "Description": "Replace Owin.IAppBuilder.Use(object, params object[]) with .UseOwin.",
           "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "Use",
+                "newMethod": "UseOwin",
+                "newParameters": "(pipeline => { pipeline(next => Invoke); })"
+              },
+              "Description": "Replace Use(object, params object[]) with UseOwin",
+              "ActionValidation": {
+                "Contains": "UseOwin",
+                "NotContains": ""
+              }
+            },
             {
               "Name": "AddComment",
               "Type": "Method",
-              "Value": "Replace Owin.IAppBuilder.Use with .UseOwin(pipeline => { pipeline(next => Invoke); }) with Invoke being the function you wanted to call in your lambda function.",
-              "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use to UseOwin.",
+              "Value": "Invoke being the function you wanted to call in your lambda function.",
+              "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use(object, params object[]) to UseOwin.",
               "ActionValidation": {
-                "Contains": "Replace Owin.IAppBuilder.Use with .UseOwin(pipeline => { pipeline(next => Invoke); })",
+                "Contains": "Invoke being the function you wanted to call in your lambda function.",
                 "NotContains": "",
                 "CheckComments": "True"
               }
@@ -127,54 +141,19 @@
               "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
             }
           ],
-          "Description": "Add a comment to help replace Owin.IAppBuilder.Use with either .UseMiddleware<MiddlewareNameHere> or .UseOwin.",
+          "Description": "Replace Owin.IAppBuilder.Use<T>(params object[]) with .UseMiddleware<MiddlewareNameHere>.",
           "Actions": [
             {
-              "Name": "AddComment",
+              "Name": "ReplaceMethodOnly",
               "Type": "Method",
-              "Value": "If this format is used \".Use<MiddlewareNameHere>\" replace with Microsoft.AspNetCore.Builder.IApplicationBuilder.UseMiddleware<MiddlewareNameHere> otherwise replace with .UseOwin(pipeline => { pipeline(next => Invoke); }) with Invoke being the function you wanted to call in your lambda function.",
-              "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use to either UseMiddleWare or UseOwin.",
+              "Value": {
+                "oldMethod": "Use",
+                "newMethod": "UseMiddleware"
+              },
+              "Description": "Replace Owin.IAppBuilder.Use<T>(params object[]) with UseMiddleware",
               "ActionValidation": {
-                "Contains": "replace with Microsoft.AspNetCore.Builder.IApplicationBuilder.UseMiddleware<MiddlewareNameHere> otherwise replace with .UseOwin",
-                "NotContains": "",
-                "CheckComments": "True"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Type": "Method",
-      "Name": "Owin.IAppBuilder.Use(System.Func<Microsoft.Owin.IOwinContext, System.Func<System.Threading.Tasks.Task>, System.Threading.Tasks.Task>)",
-      "Value": "Owin.IAppBuilder.Use(System.Func<Microsoft.Owin.IOwinContext, System.Func<System.Threading.Tasks.Task>, System.Threading.Tasks.Task>)",
-      "KeyType": "Name",
-      "ContainingType": "AppBuilderUseExtensions",
-      "RecommendedActions": [
-        {
-          "Source": "Amazon",
-          "Preferred": "Yes",
-          "TargetFrameworks": [
-            {
-              "Name": "netcoreapp3.1",
-              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
-            },
-            {
-              "Name": "net5.0",
-              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
-            }
-          ],
-          "Description": "Add a comment to help replace Owin.IAppBuilder.Use with .UseOwin.",
-          "Actions": [
-            {
-              "Name": "AddComment",
-              "Type": "Method",
-              "Value": "Replace Owin.IAppBuilder.Use with .UseOwin(pipeline => { pipeline(next => Invoke); }) with Invoke being the function you wanted to call in your lambda function.",
-              "Description": "Add a comment to explain how to migrate Owin.IAppBuilder.Use to UseOwin.",
-              "ActionValidation": {
-                "Contains": "Replace Owin.IAppBuilder.Use with .UseOwin(pipeline => { pipeline(next => Invoke); }) with Invoke",
-                "NotContains": "",
-                "CheckComments": "True"
+                "Contains": "UseMiddleware",
+                "NotContains": ""
               }
             }
           ]
@@ -204,11 +183,12 @@
           "Description": "Replace UseWebApi with UseEndpoints and add a comment to create a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces and remove System.Web.Http namespace.",
           "Actions": [
             {
-              "Name": "ReplaceMethodOnly",
+              "Name": "ReplaceMethodAndParameters",
               "Type": "Method",
               "Value": {
                 "oldMethod": "UseWebApi",
-                "newMethod": "UseEndpoints"
+                "newMethod": "UseEndpoints",
+                "newParameters": "(endpoints => { endpoints.MapControllers(); })"
               },
               "Description": "Replace UseWebApi with UseEndpoints",
               "ActionValidation": {
@@ -223,17 +203,6 @@
               "Description": "Add a comment on adding a new configureservices method.",
               "ActionValidation": {
                 "Contains": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddControllers(); }",
-                "NotContains": "",
-                "CheckComments": "True"
-              }
-            },
-            {
-              "Name": "AddComment",
-              "Type": "Method",
-              "Value": "Please setup your routes here you can use a lambda function if needed such as IApplicationBuilder.UseEndpoints(endpoints => { endpoints.MapControllers(); } );",
-              "Description": "Add a comment on how to setup your MVC controller in startup class.",
-              "ActionValidation": {
-                "Contains": "Please setup your routes here you can use a lambda function if needed such as IApplicationBuilder.UseEndpoints(endpoints => { endpoints.MapControllers(); } );",
                 "NotContains": "",
                 "CheckComments": "True"
               }
@@ -292,7 +261,7 @@
               "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
             }
           ],
-          "Description": "Add Microsoft.AspNetCore.SignalR package and replace MapSignalR with UseSignalR. Add a comment to add a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces.",
+          "Description": "Add Microsoft.AspNetCore.SignalR package and replace MapSignalR with UseEndpoints. Add a comment to add a configure services method. Add Microsoft.AspNetCore.Builder, Microsoft.Extensions.DependencyInjection namespaces.",
           "Actions": [
             {
               "Name": "AddPackage",
@@ -321,15 +290,26 @@
               }
             },
             {
-              "Name": "ReplaceMethodOnly",
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.SignalR",
+              "Description": "Add Microsoft.AspNetCore.SignalR namespace",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.SignalR;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "ReplaceMethodAndParameters",
               "Type": "Method",
               "Value": {
                 "oldMethod": "MapSignalR",
-                "newMethod": "UseSignalR"
+                "newMethod": "UseEndpoints",
+                "newParameters": "(routes => routes.MapHub<Hub>(\"pattern\"))"
               },
-              "Description": "Replace MapSignalR with UseSignalR",
+              "Description": "Replace MapSignalR with UseEndpoints",
               "ActionValidation": {
-                "Contains": "UseSignalR",
+                "Contains": "UseEndpoints",
                 "NotContains": ""
               }
             },
@@ -340,17 +320,6 @@
               "Description": "Add a comment on adding a new configureservices method.",
               "ActionValidation": {
                 "Contains": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddSignalR(); }",
-                "NotContains": "",
-                "CheckComments": "True"
-              }
-            },
-            {
-              "Name": "AddComment",
-              "Type": "Method",
-              "Value": "Please setup your signalR hub configuration here you can use a lambda function if needed such as .AddSignalR(routes => { routes.MapHub<StronglyTypedChatHub>(\"chathub\")); }",
-              "Description": "Add a comment on how to setup your MVC controller in startup class.",
-              "ActionValidation": {
-                "Contains": "Please setup your signalR hub configuration here you can use a lambda function if needed such as .AddSignalR(routes => { routes.MapHub<StronglyTypedChatHub>",
                 "NotContains": "",
                 "CheckComments": "True"
               }
@@ -439,6 +408,424 @@
                 "Contains": "Please add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { services.AddDirectoryBrowser(); }",
                 "NotContains": "",
                 "CheckComments": "True"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.CreatePerOwinContext<T>(System.Func<T>)",
+      "Value": "Owin.IAppBuilder.CreatePerOwinContext<T>(System.Func<T>)",
+      "KeyType": "Name",
+      "ContainingType": "AppBuilderExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace CreatePerOwinContext<T>(System.Func<T>) with a service in ConfigureServices method.",
+          "Actions": [
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNet.Identity.Owin",
+              "Description": "Remove Microsoft.AspNet.Identity.Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.AspNet.Identity.Owin;"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace CreatePerOwinContext<T>(System.Func<T>) and add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { Register your service here instead of using CreatePerOwinContext }. For example, app.CreatePerOwinContext(ApplicationDbContext.Create); would become: services.AddDbContext<ApplicationDbContext>(options => options.UseSqlServer(config.GetConnectionString(\"DefaultConnection\"))); ",
+              "Description": "Add a comment to explain how to replace CreatePerOwinContext<T>(System.Func<T>) with a service in ConfigureServices method.",
+              "ActionValidation": {
+                "Contains": "Please replace CreatePerOwinContext<T>(System.Func<T>) and add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { Register your service here instead of using CreatePerOwinContext }.",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>)",
+      "Value": "Owin.IAppBuilder.CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>)",
+      "KeyType": "Name",
+      "ContainingType": "AppBuilderExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>) with a service in ConfigureServices method.",
+          "Actions": [
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNet.Identity.Owin",
+              "Description": "Remove Microsoft.AspNet.Identity.Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.AspNet.Identity.Owin;"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>) and add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { Register your service here instead of using CreatePerOwinContext }. For example, app.CreatePerOwinContext(ApplicationDbContext.Create); would become: services.AddDbContext<ApplicationDbContext>(options => options.UseSqlServer(config.GetConnectionString(\"DefaultConnection\"))); ",
+              "Description": "Add a comment to explain how to replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>) with a service in ConfigureServices method.",
+              "ActionValidation": {
+                "Contains": "Please replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>) and add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { Register your service here instead of using CreatePerOwinContext }.",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>, System.Action<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, T>)",
+      "Value": "Owin.IAppBuilder.CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>, System.Action<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, T>)",
+      "KeyType": "Name",
+      "ContainingType": "AppBuilderExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            },
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Add a comment to explain how to replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>, System.Action<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, T>) with a service in ConfigureServices method.",
+          "Actions": [
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNet.Identity.Owin",
+              "Description": "Remove Microsoft.AspNet.Identity.Owin namespace",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.AspNet.Identity.Owin;"
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>, System.Action<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, T>) and add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { Register your service here instead of using CreatePerOwinContext }. For example, app.CreatePerOwinContext(ApplicationDbContext.Create); would become: services.AddDbContext<ApplicationDbContext>(options => options.UseSqlServer(config.GetConnectionString(\"DefaultConnection\"))); ",
+              "Description": "Add a comment to explain how to replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>, System.Action<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, T>) with a service in ConfigureServices method.",
+              "ActionValidation": {
+                "Contains": "Please replace CreatePerOwinContext<T>(System.Func<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, Microsoft.Owin.IOwinContext, T>, System.Action<Microsoft.AspNet.Identity.Owin.IdentityFactoryOptions<T>, T>) and add a new ConfigureServices method: public void ConfigureServices(IServiceCollection services) { Register your service here instead of using CreatePerOwinContext }.",
+                "NotContains": ""
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.UseOpenIdConnectAuthentication(string, string)",
+      "Value": "Owin.IAppBuilder.UseOpenIdConnectAuthentication(string, string)",
+      "KeyType": "Name",
+      "ContainingType": "OpenIdConnectAuthenticationExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace the UseOpenIdConnectAuthentication(string, string) with UseAuthentication and add a comment to explain how to add services.AddAuthentication().AddOpenIdConnect().",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseOpenIdConnectAuthentication",
+                "newMethod": "UseAuthentication",
+                "newParameters": "()"
+              },
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "UseAuthentication()",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+              "Description": "Add a comment to explain how to add a reference to services.AddAuthentication().AddOpenIdConnect()",
+              "ActionValidation": {
+                "Contains": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
+              }
+            }
+          ]
+        },
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace the UseOpenIdConnectAuthentication(string, string) with UseAuthentication and add a comment to explain how to add services.AddAuthentication().AddOpenIdConnect().",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseOpenIdConnectAuthentication",
+                "newMethod": "UseAuthentication",
+                "newParameters": "()"
+              },
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "UseAuthentication()",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+              "Description": "Add a comment to explain how to add a reference to services.AddAuthentication().AddOpenIdConnect()",
+              "ActionValidation": {
+                "Contains": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+                "Version": "3.1.15"
+              },
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect version 3.1.15"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Type": "Method",
+      "Name": "Owin.IAppBuilder.UseOpenIdConnectAuthentication(Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions)",
+      "Value": "Owin.IAppBuilder.UseOpenIdConnectAuthentication(Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions)",
+      "KeyType": "Name",
+      "ContainingType": "OpenIdConnectAuthenticationExtensions",
+      "RecommendedActions": [
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "net5.0",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace the UseOpenIdConnectAuthentication(string, string) with UseAuthentication and add a comment to explain how to add services.AddAuthentication().AddOpenIdConnect().",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseOpenIdConnectAuthentication",
+                "newMethod": "UseAuthentication",
+                "newParameters": "()"
+              },
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "UseAuthentication()",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+              "Description": "Add a comment to explain how to add a reference to services.AddAuthentication().AddOpenIdConnect()",
+              "ActionValidation": {
+                "Contains": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
+              }
+            }
+          ]
+        },
+        {
+          "Source": "Amazon",
+          "Preferred": "Yes",
+          "TargetFrameworks": [
+            {
+              "Name": "netcoreapp3.1",
+              "TargetCPU": [ "x86", "x64", "ARM32", "ARM64" ]
+            }
+          ],
+          "Description": "Replace the UseOpenIdConnectAuthentication(string, string) with UseAuthentication and add a comment to explain how to add services.AddAuthentication().AddOpenIdConnect().",
+          "Actions": [
+            {
+              "Name": "ReplaceMethodAndParameters",
+              "Type": "Method",
+              "Value": {
+                "oldMethod": "UseOpenIdConnectAuthentication",
+                "newMethod": "UseAuthentication",
+                "newParameters": "()"
+              },
+              "Description": "Replace the OwinMiddleware Next variable with a newly declared one _next.",
+              "ActionValidation": {
+                "Contains": "UseAuthentication()",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "AddComment",
+              "Type": "Method",
+              "Value": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+              "Description": "Add a comment to explain how to add a reference to services.AddAuthentication().AddOpenIdConnect()",
+              "ActionValidation": {
+                "Contains": "Please add services.AddAuthentication().AddOpenIdConnect(); inside of your public void ConfigureServices(IServiceCollection services) method. You can also optionally add your OpenIdConnectOptions.",
+                "NotContains": "",
+                "CheckComments": "True"
+              }
+            },
+            {
+              "Name": "AddPackage",
+              "Type": "Package",
+              "Value": {
+                "Name": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+                "Version": "3.1.15"
+              },
+              "Description": "Add package Microsoft.AspNetCore.Authentication.OpenIdConnect version 3.1.15"
+            },
+            {
+              "Name": "AddDirective",
+              "Type": "Using",
+              "Value": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "Description": "Add Microsoft.AspNetCore.Authentication.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "using Microsoft.AspNetCore.Authentication.OpenIdConnect;",
+                "NotContains": ""
+              }
+            },
+            {
+              "Name": "RemoveDirective",
+              "Type": "Using",
+              "Value": "Microsoft.Owin.Security.OpenIdConnect",
+              "Description": "Remove Microsoft.Owin.Security.OpenIdConnect",
+              "ActionValidation": {
+                "Contains": "",
+                "NotContains": "using Microsoft.Owin.Security.OpenIdConnect;"
               }
             }
           ]


### PR DESCRIPTION
*Issue #56 , #58 , #60  , #65

*Description of changes:*
We need new rules to port IHeaderDictionary and CreatePerOwinContext.

Currently we do not have rules to port RequestCookieCollection, ResponseCookieCollection and IReadableStringCollection from the Microsoft.Owin namespace.

Develop rules for Owin PathString and OpenIdConnect.

Ensure we have a 0 build error owin solution to cover all our current rules.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
