### PR TITLE
Adding tests for Template files too

### DIFF
--- a/RecommendationTools/UnitTests/S3SyncTests.cs
+++ b/RecommendationTools/UnitTests/S3SyncTests.cs
@@ -37,7 +37,7 @@ namespace PostSyncTests
             var zipBytes = await httpClient.GetByteArrayAsync("https://github.com/aws/porting-assistant-dotnet-datastore/archive/refs/heads/master.zip");
             await File.WriteAllBytesAsync("github.zip", zipBytes);
             Directory.CreateDirectory(TempExtractDir);
-            ZipFile.ExtractToDirectory("github.zip", "masterBranchCode");
+            ZipFile.ExtractToDirectory("github.zip", TempExtractDir);
             var pathToRepoRecs = $@"{TempExtractDir}\porting-assistant-dotnet-datastore-master\recommendation";
             var pathToRepoTemplates = $@"{TempExtractDir}\porting-assistant-dotnet-datastore-master\Templates";
 
@@ -50,7 +50,7 @@ namespace PostSyncTests
             {
                 foreach(var file in allRepoFilesToCheck)
                 {
-                    var s3ObjectPath = $"{S3UrlPrefix}/{file.Replace(@"masterBranchCode\porting-assistant-dotnet-datastore-master\", "").Replace(@"\", "/")}";
+                    var s3ObjectPath = $"{S3UrlPrefix}/{file.Replace(@$"{TempExtractDir}\porting-assistant-dotnet-datastore-master\", "").Replace(@"\", "/")}";
                     var s3Content = await httpClient.GetStringAsync(s3ObjectPath);
                     var localContent = await File.ReadAllTextAsync(file);
                     localContent = localContent.Replace("\r\n", "\n", StringComparison.Ordinal);


### PR DESCRIPTION
*Description of changes:*
There are 2 reasons for this change. One is that I wasn't testing that the Template files were being synced correctly, and we just had an issue with one of those causing failing tests. Two is that I want to test another merge into the master branch to make sure the pipeline is updated correctly and that it only pushes data to S3 from the master branch. Previously it was pushing data from feature branches, which is what caused the issue with the Template files yesterday. By merging this to master, it will kick off the pipeline in the real way for testing the webhook. 

I validated that this works by changing a file in the S3 datastore and checking that the test fails in that case. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
