### PR TITLE
Add NuGet package source mapping for internal packages

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,4 +5,12 @@
     <!-- <add key="dotnet" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" /> -->
     <add key="encore-nuget" value="https://s3-us-west-2.amazonaws.com/aws.portingassistant.dotnet.download/nuget/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="encore-nuget">
+      <package pattern="CTA.*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
`CTA.Rules.Models` is hosted on the `encore-nuget` feed but `NuGet.Config` has no `packageSourceMapping`, so NuGet queries all configured sources for it. This adds source mapping to pin `CTA.*` packages to the `encore-nuget` feed.